### PR TITLE
Initialize Setup Poetry Action

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -15,18 +15,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.0.0
 
-      # Modify the following steps for testing your composite action.
-      # Learn more: https://docs.github.com/en/actions/automating-builds-and-tests
-
-      - name: Test directory should not exist
+      - name: Poetry should not be available
         shell: bash
-        run: "! test -d dir"
+        run: "! poetry --version"
 
-      - name: Create test directory
+      - name: Setup Poetry
         uses: ./
-        with:
-          name: dir
 
-      - name: Test directory should exist
+      - name: Poetry should be available
         shell: bash
-        run: test -d dir
+        run: poetry --version

--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,21 @@
-This is free and unencumbered software released into the public domain.
+MIT License
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Copyright (c) 2023 Alfi Maulana
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-For more information, please refer to <http://unlicense.org/>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/setup-poetry-action/action.yaml?label=test&branch=main&style=flat-square)](https://github.com/threeal/setup-poetry-action/actions/workflows/action.yaml)
 
 The Setup Poetry Action is a [GitHub Action](https://github.com/features/actions) designed to streamline the setup of [Poetry](https://python-poetry.org/), a powerful dependency and packaging manager for [Python](https://www.python.org/) projects. This action allows you to easily configure and use a specific version of Poetry within your GitHub Actions workflow, enabling you to build and test your Python project seamlessly.
+
+## License
+
+This project is licensed under the terms of the [MIT License](./LICENSE).
+
+Copyright © 2023 [Alfi Maulana](https://github.com/threeal/)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,7 @@
-<!-- Clear the content of this file and replace it with the description of your project. -->
-<!-- Learn more: https://www.makeareadme.com -->
+# Setup Poetry Action
 
-# Composite Action Starter
+[![version](https://img.shields.io/github/v/release/threeal/setup-poetry-action?style=flat-square)](https://github.com/threeal/setup-poetry-action/releases)
+[![license](https://img.shields.io/github/license/threeal/setup-poetry-action?style=flat-square)](./LICENSE)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/setup-poetry-action/action.yaml?label=test&branch=main&style=flat-square)](https://github.com/threeal/setup-poetry-action/actions/workflows/action.yaml)
 
-[![version](https://img.shields.io/github/v/release/threeal/composite-action-starter?style=flat-square)](https://github.com/threeal/composite-action-starter/releases)
-[![license](https://img.shields.io/github/license/threeal/composite-action-starter?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/composite-action-starter/action.yaml?label=test&branch=main&style=flat-square)](https://github.com/threeal/composite-action-starter/actions/workflows/build.yaml)
-
-The Composite Action Starter is a [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) that provides a minimalistic boilerplate to kickstart your [GitHub composite action](https://github.com/features/actions) project.
-Use this template to initialize your project with predefined file structures and preconfigured settings recommended for a GitHub composite action project.
-
-## Key Features
-
-- Includes a predefined GitHub Actions metadata file that you can easily modify.
-- Comes with a predefined GitHub Actions workflow for testing your composite action.
-- Includes preconfigured [Dependabot](https://docs.github.com/en/code-security/dependabot) settings to keep your composite action dependencies up to date.
-
-## Usage
-
-Refer to [this wiki](https://github.com/threeal/composite-action-starter/wiki) for information on how to use this template.
+The Setup Poetry Action is a [GitHub Action](https://github.com/features/actions) designed to streamline the setup of [Poetry](https://python-poetry.org/), a powerful dependency and packaging manager for [Python](https://www.python.org/) projects. This action allows you to easily configure and use a specific version of Poetry within your GitHub Actions workflow, enabling you to build and test your Python project seamlessly.

--- a/action.yaml
+++ b/action.yaml
@@ -1,18 +1,11 @@
-# Modify the following action metadata according to the specification of your composite action.
-# Learn more: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
-
-name: Mkdir Action
+name: Setup Poetry
 author: Alfi Maulana
-description: Create a new directory
+description: Set up a specific version of Poetry
 branding:
   color: black
-  icon: folder-plus
-inputs:
-  name:
-    description: Name of the directory to create
-    required: true
+  icon: terminal
 runs:
   using: composite
   steps:
     - shell: bash
-      run: mkdir ${{ inputs.name }}
+      run: pipx install poetry


### PR DESCRIPTION
This pull request initializes the Setup Poetry Action by making the following changes:

- Changed `LICENSE.md` to the [MIT License](https://opensource.org/license/mit/).
- Filled in the project description in the `README.md`.
- Modified the `action.yaml` metadata file to set up Poetry.
- Modified the `action.yaml` workflow file to test the Poetry setup.