### PR TITLE
 Introduce `version` Input

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -29,3 +29,12 @@ jobs:
       - name: Poetry version should be correct
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version 1.6.1)'
+
+      - name: Setup Poetry with a specific version
+        uses: ./
+        with:
+          version: 1.5.1
+
+      - name: Poetry version should be correct
+        shell: bash
+        run: test "$(poetry --version)" == 'Poetry (version 1.5.1)'

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -17,11 +17,15 @@ jobs:
 
       - name: Poetry should not be available
         shell: bash
-        run: "! poetry --version"
+        run: "! which poetry"
 
       - name: Setup Poetry
         uses: ./
 
       - name: Poetry should be available
         shell: bash
-        run: poetry --version
+        run: which poetry
+
+      - name: Poetry version should be correct
+        shell: bash
+        run: test "$(poetry --version)" == 'Poetry (version 1.6.1)'

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ To get started with the Setup Poetry Action, you can refer to the [action.yaml](
 
 Here are the available input parameters for the Setup Poetry Action:
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `version` | Version number or `latest` | Specify the version of Poetry you want to set up using this action. You can refer to the [Poetry release history](https://pypi.org/project/poetry/#history) for information on the versions available for setup. |
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `version` | Version number or `latest` | `latest` | Specify the version of Poetry to be set up using this action. You can refer to the [Poetry release history](https://pypi.org/project/poetry/#history) for information about the available versions for setup. |
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 The Setup Poetry Action is a [GitHub Action](https://github.com/features/actions) designed to streamline the setup of [Poetry](https://python-poetry.org/), a powerful dependency and packaging manager for [Python](https://www.python.org/) projects. This action allows you to easily configure and use a specific version of Poetry within your GitHub Actions workflow, enabling you to build and test your Python project seamlessly.
 
+## Usage
+
+To get started with the Setup Poetry Action, you can refer to the [action.yaml](./action.yaml) file for detailed configuration options. Additionally, if you are new to GitHub Actions, you can explore the [GitHub Actions guide](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) for a comprehensive overview.
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Here are the available input parameters for the Setup Poetry Action:
 | --- | --- | --- |
 | `version` | Version number or `latest` | Specify the version of Poetry you want to set up using this action. You can refer to the [Poetry release history](https://pypi.org/project/poetry/#history) for information on the versions available for setup. |
 
-### Example
+### Examples
 
-Here's an example of how to use the Setup Poetry Action to set up Poetry for installing the dependencies of a Python project in your GitHub Actions workflow:
+Here is the basic example of how to use the Setup Poetry Action to set up Poetry for installing the dependencies of a Python project in your GitHub Actions workflow:
 
 ```yaml
 name: Python CI
@@ -40,6 +40,33 @@ jobs:
         run: poetry install
 
       # Add more steps as needed for your workflow
+```
+
+#### Specifying Poetry Version
+
+You can specify the Poetry version to be used by providing it as an input parameter:
+
+```yaml
+- name: Setup Poetry
+  uses: threeal/setup-poetry-action@main
+  with:
+    version: 1.5.1
+```
+
+#### Combining with Setup Python Action
+
+To set both the Python and Poetry versions, you can combine the Setup Poetry Action with the [Setup Python](https://github.com/actions/setup-python) action:
+
+```yaml
+- name: Setup Python
+  uses: actions/setup-python@4.7.0
+  with:
+    python-version: 3.11
+
+- name: Setup Poetry
+  uses: threeal/setup-poetry-action@main
+  with:
+    version: 1.5.1
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ The Setup Poetry Action is a [GitHub Action](https://github.com/features/actions
 
 To get started with the Setup Poetry Action, you can refer to the [action.yaml](./action.yaml) file for detailed configuration options. Additionally, if you are new to GitHub Actions, you can explore the [GitHub Actions guide](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) for a comprehensive overview.
 
+### Inputs
+
+Here are the available input parameters for the Setup Poetry Action:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `version` | Version number or `latest` | Specify the version of Poetry you want to set up using this action. You can refer to the [Poetry release history](https://pypi.org/project/poetry/#history) for information on the versions available for setup. |
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@ Here are the available input parameters for the Setup Poetry Action:
 | --- | --- | --- |
 | `version` | Version number or `latest` | Specify the version of Poetry you want to set up using this action. You can refer to the [Poetry release history](https://pypi.org/project/poetry/#history) for information on the versions available for setup. |
 
+### Example
+
+Here's an example of how to use the Setup Poetry Action to set up Poetry for installing the dependencies of a Python project in your GitHub Actions workflow:
+
+```yaml
+name: Python CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.0.0
+
+      - name: Setup Poetry
+        uses: threeal/setup-poetry-action@main
+
+      - name: Install Dependencies
+        run: poetry install
+
+      # Add more steps as needed for your workflow
+```
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).

--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ runs:
     - shell: bash
       run: |
         if [ '${{ inputs.version }}' == latest ]; then
-          pipx install poetry
+          pipx install poetry --force
         else
-          pipx install poetry==${{ inputs.version }}
+          pipx install poetry==${{ inputs.version }} --force
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -4,8 +4,18 @@ description: Set up a specific version of Poetry
 branding:
   color: black
   icon: terminal
+inputs:
+  version:
+    description: Poetry version to be set up
+    required: false
+    default: latest
 runs:
   using: composite
   steps:
     - shell: bash
-      run: pipx install poetry
+      run: |
+        if [ '${{ inputs.version }}' == latest ]; then
+          pipx install poetry
+        else
+          pipx install poetry==${{ inputs.version }}
+        fi


### PR DESCRIPTION
This pull request introduces the following changes:

- Added a `version` input for specifying the Poetry version to be set up by the Setup Poetry Action.
- Updated the workflow file to test the Poetry set up with a specific version.
- Updated the `README.md` file with usage and examples information.

It eventually resolves #2.