### PR TITLE
Add Caching Support

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
         run: "! which poetry"
 
-      - name: Setup Poetry
+      - name: Setup Poetry with caching
         uses: ./
 
       - name: Poetry should be available
@@ -34,7 +34,17 @@ jobs:
         uses: ./
         with:
           version: 1.5.1
+          cache: false
 
       - name: Poetry version should be correct
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version 1.5.1)'
+
+      - name: Setup Poetry
+        uses: ./
+        with:
+          cache: false
+
+      - name: Poetry version should be correct
+        shell: bash
+        run: test "$(poetry --version)" == 'Poetry (version 1.6.1)'

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Here are the available input parameters for the Setup Poetry Action:
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `version` | Version number or `latest` | `latest` | Specify the version of Poetry to be set up using this action. You can refer to the [Poetry release history](https://pypi.org/project/poetry/#history) for information about the available versions for setup. |
+| `cache` | `true` or `false` | `true` | Indicates whether to use caching during Poetry installation. |
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ To set both the Python and Poetry versions, you can combine the Setup Poetry Act
     version: 1.5.1
 ```
 
+#### Disable Caching
+
+By default, caching is enabled. To disable caching, set the `cache` input parameter to `false` as shown below:
+
+```yaml
+- name: Setup Poetry without caching
+  uses: threeal/setup-poetry-action@main
+  with:
+    cache: false
+```
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 The Setup Poetry Action is a [GitHub Action](https://github.com/features/actions) designed to streamline the setup of [Poetry](https://python-poetry.org/), a powerful dependency and packaging manager for [Python](https://www.python.org/) projects. This action allows you to easily configure and use a specific version of Poetry within your GitHub Actions workflow, enabling you to build and test your Python project seamlessly.
 
+## Key Features
+
+The Setup Poetry Action offers the following key features:
+
+- **Easy Setup:** Quickly make Poetry available in your GitHub Actions workflow.
+- **Version Flexibility:** Specify the desired version of Poetry for your project.
+- **Caching Support:** Speed up the Poetry setup process with caching for improved efficiency.
+
 ## Usage
 
 To get started with the Setup Poetry Action, you can refer to the [action.yaml](./action.yaml) file for detailed configuration options. Additionally, if you are new to GitHub Actions, you can explore the [GitHub Actions guide](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) for a comprehensive overview.

--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,7 @@ runs:
       run: |
         if [ '${{ inputs.version }}' == latest ]; then
           pipx install poetry --force
+          pipx upgrade poetry --force
         else
           pipx install poetry==${{ inputs.version }} --force
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -6,13 +6,18 @@ branding:
   icon: terminal
 inputs:
   version:
-    description: Poetry version to be set up
+    description: The Poetry version to be set up.
     required: false
     default: latest
+  cache:
+    description: Use caching during Poetry installation.
+    required: false
+    default: true
 runs:
   using: composite
   steps:
     - id: pipx
+      if: inputs.cache == 'true'
       shell: bash
       run: |
         echo "version=$(pipx --version)" >> $GITHUB_OUTPUT
@@ -20,6 +25,7 @@ runs:
         echo "local_venvs=$(pipx environment -v PIPX_LOCAL_VENVS)" >> $GITHUB_OUTPUT
 
     - id: cache
+      if: inputs.cache == 'true'
       uses: actions/cache@v3.3.1
       with:
         path: |
@@ -28,7 +34,7 @@ runs:
         key: pipx-${{ steps.pipx.outputs.version }}-${{ runner.os }}-poetry-${{ inputs.version }}
 
     - shell: bash
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'
       run: |
         if [ '${{ inputs.version }}' == latest ]; then
           pipx install poetry --force

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,23 @@ inputs:
 runs:
   using: composite
   steps:
+    - id: pipx
+      shell: bash
+      run: |
+        echo "version=$(pipx --version)" >> $GITHUB_OUTPUT
+        echo "bin_dir=$(pipx environment -v PIPX_BIN_DIR)" >> $GITHUB_OUTPUT
+        echo "local_venvs=$(pipx environment -v PIPX_LOCAL_VENVS)" >> $GITHUB_OUTPUT
+
+    - id: cache
+      uses: actions/cache@v3.3.1
+      with:
+        path: |
+          ${{ steps.pipx.outputs.bin_dir }}/poetry*
+          ${{ steps.pipx.outputs.local_venvs }}/poetry
+        key: pipx-${{ steps.pipx.outputs.version }}-${{ runner.os }}-poetry-${{ inputs.version }}
+
     - shell: bash
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         if [ '${{ inputs.version }}' == latest ]; then
           pipx install poetry --force


### PR DESCRIPTION
This pull request introduces the following changes:

- Implemented caching for Poetry installation to enhance setup time.
- Added the `cache` input to allow users to specify whether caching should be used or not.
- Updated the workflow to include testing for Poetry installation caching.
- Included a "Key Features" section and an example on how to disable caching in the `README.md`.

It eventually resolves #3.