### PR TITLE
Assert Poetry Version Using Environment Variable in Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Poetry version should be correct
         shell: bash
-        run: test "$(poetry --version)" == 'Poetry (version 1.6.1)'
+        run: test "$(poetry --version)" == 'Poetry (version ${{ vars.POETRY_LATEST_VERSION }})'
 
       - name: Setup Poetry with a specific version
         uses: ./
@@ -48,4 +48,4 @@ jobs:
 
       - name: Poetry version should be correct
         shell: bash
-        run: test "$(poetry --version)" == 'Poetry (version 1.6.1)'
+        run: test "$(poetry --version)" == 'Poetry (version ${{ vars.POETRY_LATEST_VERSION }})'


### PR DESCRIPTION
This pull request resolves #16 by using `POETRY_LATEST_VERSION` variable for asserting Poetry version in the CI workflow.