### PR TITLE
Rename CI Workflow to Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,12 +1,12 @@
-name: CI
+name: Test
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  test:
-    name: Test
+  test-action:
+    name: Test Action
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,36 +19,36 @@ jobs:
           path: setup-poetry-action
           sparse-checkout: action.yaml
 
-      - name: Poetry should not be available
+      - name: Poetry Should Not Be Available
         shell: bash
         run: "! which poetry"
 
-      - name: Setup Poetry with caching
+      - name: Setup Poetry
         uses: ./setup-poetry-action
 
-      - name: Poetry should be available
+      - name: Poetry Should Be Available
         shell: bash
         run: which poetry
 
-      - name: Poetry version should be correct
+      - name: Ensure Poetry Version Is Correct
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version ${{ vars.POETRY_LATEST_VERSION }})'
 
-      - name: Setup Poetry with a specific version
+      - name: Setup Poetry With a Specific Version
         uses: ./setup-poetry-action
         with:
           version: 1.5.1
           cache: false
 
-      - name: Poetry version should be correct
+      - name: Ensure Poetry Version Is Correct
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version 1.5.1)'
 
-      - name: Setup Poetry
+      - name: Setup Poetry Without Cache
         uses: ./setup-poetry-action
         with:
           cache: false
 
-      - name: Poetry version should be correct
+      - name: Ensure Poetry Version Is Correct
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version ${{ vars.POETRY_LATEST_VERSION }})'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [Windows, Ubuntu, macOS]
+        os: [windows, ubuntu, macos]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![version](https://img.shields.io/github/v/release/threeal/setup-poetry-action?style=flat-square)](https://github.com/threeal/setup-poetry-action/releases)
 [![license](https://img.shields.io/github/license/threeal/setup-poetry-action?style=flat-square)](./LICENSE)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/setup-poetry-action/ci.yaml?label=test&branch=main&style=flat-square)](https://github.com/threeal/setup-poetry-action/actions/workflows/ci.yaml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/setup-poetry-action/test.yaml?label=test&branch=main&style=flat-square)](https://github.com/threeal/setup-poetry-action/actions/workflows/test.yaml)
 
 The Setup Poetry Action is a [GitHub Action](https://github.com/features/actions) designed to streamline the setup of [Poetry](https://python-poetry.org/), a powerful dependency and packaging manager for [Python](https://www.python.org/) projects. This action allows you to easily configure and use a specific version of Poetry within your GitHub Actions workflow, enabling you to build and test your Python project seamlessly.
 


### PR DESCRIPTION
This pull request resolves #22 by renaming the `ci.yaml` workflow to `test.yaml` workflow. This change also rename the action, jobs, matrix OSs, and steps respectively.