### PR TITLE
Separate Test Action Job in Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,18 +19,10 @@ jobs:
           path: setup-poetry-action
           sparse-checkout: action.yaml
 
-      - name: Poetry Should Not Be Available
-        shell: bash
-        run: "! which poetry"
-
       - name: Setup Poetry
         uses: ./setup-poetry-action
 
-      - name: Poetry Should Be Available
-        shell: bash
-        run: which poetry
-
-      - name: Ensure Poetry Version Is Correct
+      - name: Check Poetry Version
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version ${{ vars.POETRY_LATEST_VERSION }})'
 
@@ -40,7 +32,7 @@ jobs:
           version: 1.5.1
           cache: false
 
-      - name: Ensure Poetry Version Is Correct
+      - name: Check Poetry Version
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version 1.5.1)'
 
@@ -49,6 +41,6 @@ jobs:
         with:
           cache: false
 
-      - name: Ensure Poetry Version Is Correct
+      - name: Check Poetry Version
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version ${{ vars.POETRY_LATEST_VERSION }})'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,16 @@ jobs:
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version ${{ vars.POETRY_LATEST_VERSION }})'
 
+  test-action-with-specific-poetry-version:
+    name: Test Action With Specific Poetry Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          path: setup-poetry-action
+          sparse-checkout: action.yaml
+
       - name: Setup Poetry With a Specific Version
         uses: ./setup-poetry-action
         with:
@@ -35,6 +45,16 @@ jobs:
       - name: Check Poetry Version
         shell: bash
         run: test "$(poetry --version)" == 'Poetry (version 1.5.1)'
+
+  test-action-without-cache:
+    name: Test Action Without Cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          path: setup-poetry-action
+          sparse-checkout: action.yaml
 
       - name: Setup Poetry Without Cache
         uses: ./setup-poetry-action


### PR DESCRIPTION
This pull request resolves #24 by separating the `test-action` job into 3 different jobs: `test-action`, `test-action-with-specific-version`, and `test-action-without-cache`. This pull request also simplify steps for checking if Poetry is successfully installed.