### PR TITLE
Do Not Specify Input Requirement If False in `action.yaml`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -6,12 +6,10 @@ branding:
   icon: terminal
 inputs:
   version:
-    description: The Poetry version to be set up.
-    required: false
+    description: The Poetry version to be set up
     default: latest
   cache:
-    description: Use caching during Poetry installation.
-    required: false
+    description: Use caching during Poetry installation
     default: true
 runs:
   using: composite


### PR DESCRIPTION
This pull request resolves #28 by removing the `required: false` properties in the action inputs configuration of the `action.yaml` file.