### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Setup Poetry Action
 
-[![version](https://img.shields.io/github/v/release/threeal/setup-poetry-action?style=flat-square)](https://github.com/threeal/setup-poetry-action/releases)
-[![license](https://img.shields.io/github/license/threeal/setup-poetry-action?style=flat-square)](./LICENSE)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/setup-poetry-action/test.yaml?label=test&branch=main&style=flat-square)](https://github.com/threeal/setup-poetry-action/actions/workflows/test.yaml)
-
 The Setup Poetry Action is a [GitHub Action](https://github.com/features/actions) designed to streamline the setup of [Poetry](https://python-poetry.org/), a powerful dependency and packaging manager for [Python](https://www.python.org/) projects. This action allows you to easily configure and use a specific version of Poetry within your GitHub Actions workflow, enabling you to build and test your Python project seamlessly.
 
 ## Key Features


### PR DESCRIPTION
This pull request resolves #35 by simply removing badges from the root `README.md` file.